### PR TITLE
Update searchFiles test to use sync and remove callback

### DIFF
--- a/test/searchFiles.js
+++ b/test/searchFiles.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const { expect } = require("chai");
 
-const searchFiles = require("../src/searchFiles");
+const searchFiles = require("../index");
 const directoryPath = path.join(__dirname, "temp");
 
 /**

--- a/test/searchFiles.js
+++ b/test/searchFiles.js
@@ -1,8 +1,8 @@
 const fs = require("fs");
 const path = require("path");
-const searchFiles = require("../index");
 const { expect } = require("chai");
 
+const searchFiles = require("../src/searchFiles");
 const directoryPath = path.join(__dirname, "temp");
 
 /**
@@ -35,54 +35,26 @@ describe("searchFiles()", function () {
      */
 
     // temp directory files and directories
-    fs.mkdirSync(directoryPath, { recursive: true }, function (err) {
-      if (err) throw err;
-    });
+    fs.mkdirSync(directoryPath, { recursive: true });
 
-    fs.writeFileSync(testPath("words.txt"), "Words file", function (err) {
-      if (err) throw err;
-    });
-
-    fs.writeFileSync(testPath("blob.txt"), "Blob file", function (err) {
-      if (err) throw err;
-    });
-
-    fs.writeFileSync(testPath("javascript.js"), "JS file", function (err) {
-      if (err) throw err;
-    });
+    fs.writeFileSync(testPath("words.txt"), "Words file");
+    fs.writeFileSync(testPath("blob.txt"), "Blob file");
+    fs.writeFileSync(testPath("javascript.js"), "JS file");
 
     // temp/empty directory files and directories
-    fs.mkdirSync(testPath("emptyDir"), { recursive: true }, function (err) {
-      if (err) throw err;
-    });
+    fs.mkdirSync(testPath("emptyDir"), { recursive: true });
 
     // temp/innerDir directory files and directories
-    fs.mkdirSync(testPath("innerDir"), { recursive: true }, function (err) {
-      if (err) throw err;
-    });
+    fs.mkdirSync(testPath("innerDir"), { recursive: true });
 
-    fs.writeFileSync(testPath("innerDir", "inner.txt"), "Inner", function (err) {
-      if (err) throw err;
-    });
-
-    fs.writeFileSync(testPath("innerDir", "inner.js"), "Inner", function (err) {
-      if (err) throw err;
-    });
+    fs.writeFileSync(testPath("innerDir", "inner.txt"), "Inner");
+    fs.writeFileSync(testPath("innerDir", "inner.js"), "Inner");
 
     // temp/innerDir/src/components files and directories
-    fs.mkdirSync(testPath("innerDir", "src", "components"), { recursive: true }, function (err) {
-      if (err) throw err;
-    });
+    fs.mkdirSync(testPath("innerDir", "src", "components"), { recursive: true });
 
-    fs.writeFileSync(testPath("innerDir", "src", "components", "app.py"), "import math", function (
-      err
-    ) {
-      if (err) throw err;
-    });
-
-    fs.writeFileSync(testPath("innerDir", "src", "init.py"), "import sys", function (err) {
-      if (err) throw err;
-    });
+    fs.writeFileSync(testPath("innerDir", "src", "components", "app.py"), "import math");
+    fs.writeFileSync(testPath("innerDir", "src", "init.py"), "import sys");
 
     done();
   });


### PR DESCRIPTION
# Description

Update `test/searchFiles.js` to use `mkdirSync` and `writeFileSync` instead of their `async` variants. These `sync` versions do not have callbacks.

# Test process

- [x] searchFiles()

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
